### PR TITLE
Add Mira to Mobile Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Use your browser’s find (Ctrl+F or Cmd+F) or jump via the table:
 - [Hashcat](https://hashcat.net/hashcat) [F] [Linux macOS Windows] — GPU/CPU password cracking.
 - [John the Ripper Jumbo](https://www.openwall.com/john/) [F] [Linux macOS Windows] — Password/cracking suite.
 
+- [Mira](https://github.com/vwww-droid/Mira) [F] — Runtime protection analysis platform for third-party Android and iOS apps, enabling AI to use host-app-side shell, Java, Native, and Frida capabilities for environment risk detection and hardening validation.
 [Back to Top](#navigation)
 
 ---


### PR DESCRIPTION
## Summary
Add Mira to the Mobile Security section.

## Why
Mira is an Android and iOS runtime protection analysis platform for third-party target apps. It enables AI to use host-app-side shell, Java, Native, and Frida capabilities for environment risk detection and hardening validation.

## Project
- Repo: https://github.com/vwww-droid/Mira

## Notes
- Formatting matches existing entries.
- Entry is placed under Mobile Security.
